### PR TITLE
feat: add per-site Suspend/Reinstate for internal approval detail view

### DIFF
--- a/disturbance/components/approvals/api.py
+++ b/disturbance/components/approvals/api.py
@@ -10,7 +10,7 @@ from rest_framework.renderers import JSONRenderer
 from datetime import datetime
 
 from disturbance.components.approvals.models import (
-    Approval, ApprovalUserAction, ApprovalDocument,
+    Approval, ApprovalUserAction, ApprovalDocument, ApiarySiteOnApproval,
 )
 from disturbance.components.approvals.serializers import (
     ApprovalSerializer,
@@ -271,6 +271,50 @@ class ApprovalViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
             instance.reinstate_approval(request)
             serializer = self.get_serializer(instance)
             return Response(serializer.data)
+        except serializers.ValidationError:
+            print(traceback.print_exc())
+            raise
+        except ValidationError as e:
+            handle_validation_error(e)
+        except Exception as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(str(e))
+
+    @action(detail=True, methods=['POST'], permission_classes=[InternalApprovalPermission])
+    def suspend_apiary_site(self, request, *args, **kwargs):
+        try:
+            instance = self.get_object()
+            apiary_site_id = request.data.get('apiary_site_id')
+            if not apiary_site_id:
+                raise serializers.ValidationError({'apiary_site_id': 'This field is required.'})
+            instance.suspend_apiary_site(request, apiary_site_id)
+            updated_qs = ApiarySiteOnApproval.objects.filter(
+                approval=instance, apiary_site_id=apiary_site_id
+            )
+            result = list(annotate_apiary_site_on_approval_geometry(updated_qs))
+            return Response(result[0])
+        except serializers.ValidationError:
+            print(traceback.print_exc())
+            raise
+        except ValidationError as e:
+            handle_validation_error(e)
+        except Exception as e:
+            print(traceback.print_exc())
+            raise serializers.ValidationError(str(e))
+
+    @action(detail=True, methods=['POST'], permission_classes=[InternalApprovalPermission])
+    def reinstate_apiary_site(self, request, *args, **kwargs):
+        try:
+            instance = self.get_object()
+            apiary_site_id = request.data.get('apiary_site_id')
+            if not apiary_site_id:
+                raise serializers.ValidationError({'apiary_site_id': 'This field is required.'})
+            instance.reinstate_apiary_site(request, apiary_site_id)
+            updated_qs = ApiarySiteOnApproval.objects.filter(
+                approval=instance, apiary_site_id=apiary_site_id
+            )
+            result = list(annotate_apiary_site_on_approval_geometry(updated_qs))
+            return Response(result[0])
         except serializers.ValidationError:
             print(traceback.print_exc())
             raise

--- a/disturbance/components/approvals/models.py
+++ b/disturbance/components/approvals/models.py
@@ -480,14 +480,18 @@ class Approval(RevisionedMixin):
 
     def change_apiary_site_status(self, approval_status):
         relations = self.get_relations()
-        if approval_status in (Approval.STATUS_CANCELLED, Approval.STATUS_SUSPENDED, Approval.STATUS_SURRENDERED,):
+        if approval_status in (Approval.STATUS_CANCELLED, Approval.STATUS_SURRENDERED,):
             relations.update(site_status=SITE_STATUS_NOT_TO_BE_REISSUED)
+        elif approval_status == Approval.STATUS_SUSPENDED:
+            # Preserve individually-suspended sites during approval-level suspension
+            relations.exclude(site_status=SITE_STATUS_SUSPENDED).update(site_status=SITE_STATUS_NOT_TO_BE_REISSUED)
         elif approval_status == Approval.STATUS_EXPIRED:
             for apiary_site in self.apiary_sites.all():
                 apiary_site.make_vacant(True, apiary_site.latest_approval_link)
             relations.update(available=False)
         elif approval_status == Approval.STATUS_CURRENT:
-            relations.update(site_status=SITE_STATUS_CURRENT)
+            # Restore only NOT_TO_BE_REISSUED sites; preserve individually-suspended ones
+            relations.filter(site_status=SITE_STATUS_NOT_TO_BE_REISSUED).update(site_status=SITE_STATUS_CURRENT)
 
     def approval_cancellation(self,request,details):
         with transaction.atomic():
@@ -595,6 +599,42 @@ class Approval(RevisionedMixin):
             except:
                 raise
 
+    def suspend_apiary_site(self, request, apiary_site_id):
+        with transaction.atomic():
+            if self.status != Approval.STATUS_CURRENT:
+                raise ValidationError('Cannot suspend a site unless the approval is current')
+            if not self.can_action:
+                raise ValidationError('A pending scheduled action prevents site-level changes')
+            site_on_approval = ApiarySiteOnApproval.objects.get(
+                approval=self, apiary_site_id=apiary_site_id
+            )
+            if site_on_approval.site_status != SITE_STATUS_CURRENT:
+                raise ValidationError('Site is not current and cannot be suspended')
+            site_on_approval.site_status = SITE_STATUS_SUSPENDED
+            site_on_approval.save()
+            self.log_user_action(
+                ApprovalUserAction.ACTION_SUSPEND_APIARY_SITE.format(apiary_site_id, self.lodgement_number),
+                request
+            )
+
+    def reinstate_apiary_site(self, request, apiary_site_id):
+        with transaction.atomic():
+            if self.status != Approval.STATUS_CURRENT:
+                raise ValidationError('Cannot reinstate a site unless the approval is current')
+            if not self.can_action:
+                raise ValidationError('A pending scheduled action prevents site-level changes')
+            site_on_approval = ApiarySiteOnApproval.objects.get(
+                approval=self, apiary_site_id=apiary_site_id
+            )
+            if site_on_approval.site_status != SITE_STATUS_SUSPENDED:
+                raise ValidationError('Site is not suspended and cannot be reinstated')
+            site_on_approval.site_status = SITE_STATUS_CURRENT
+            site_on_approval.save()
+            self.log_user_action(
+                ApprovalUserAction.ACTION_REINSTATE_APIARY_SITE.format(apiary_site_id, self.lodgement_number),
+                request
+            )
+
     def approval_surrender(self,request,details):
         with transaction.atomic():
             try:
@@ -672,6 +712,8 @@ class ApprovalUserAction(UserAction):
     ACTION_AMEND_APPROVAL = "Create amendment Proposal for approval {}"
     ACTION_APPROVAL_PDF_VIEW ="View approval PDF for approval {}"
     ACTION_UPDATE_NO_CHARGE_DATE_UNTIL = "'Do not charge annual site fee until' date updated to {} for approval {}"
+    ACTION_SUSPEND_APIARY_SITE = "Suspend apiary site {} of approval {}"
+    ACTION_REINSTATE_APIARY_SITE = "Reinstate apiary site {} of approval {}"
 
     class Meta:
         app_label = 'disturbance'

--- a/disturbance/components/proposals/models.py
+++ b/disturbance/components/proposals/models.py
@@ -3810,7 +3810,8 @@ class ProposalApiary(RevisionedMixin):
                 apiary_site_on_approval.zone = apiary_site_on_proposal.zone
                 apiary_site_on_approval.catchment = apiary_site_on_proposal.catchment
                 apiary_site_on_approval.dra_permit = apiary_site_on_proposal.dra_permit
-                apiary_site_on_approval.site_status = SITE_STATUS_CURRENT
+                if asoa_created:
+                    apiary_site_on_approval.site_status = SITE_STATUS_CURRENT
                 apiary_site_on_approval.save()
             else:
                 try:

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -618,6 +618,8 @@
                 $("#" + this.table_id).on('click', 'input[class="select_all_checkbox"]', this.checkboxSelectAll)
                 $("#" + this.table_id).on('click', 'a[data-make-vacant]', this.makeVacantClicked)
                 $("#" + this.table_id).on('click', 'a[data-contact-licence-holder]', this.contactLicenceHolder)
+                $("#" + this.table_id).on('click', 'a[data-suspend-site]', this.suspendApiarySite)
+                $("#" + this.table_id).on('click', 'a[data-reinstate-site]', this.reinstateApiarySite)
 
                 $("#" + this.table_id).on('mouseenter', "tr", this.mouseEnter)
                 $("#" + this.table_id).on('mouseleave', "tr", this.mouseLeave)

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -838,7 +838,15 @@
                             break;
                         }
                     }
+                    for (let i = 0; i < vm.apiary_site_geojson_array.length; i++) {
+                        if (vm.apiary_site_geojson_array[i].id == apiary_site_id) {
+                            vm.apiary_site_geojson_array[i] = site_updated;
+                            break;
+                        }
+                    }
                     vm.constructApiarySitesTable(vm.apiary_sites_local);
+                    vm.$refs.component_map.removeApiarySiteById(apiary_site_id);
+                    vm.$refs.component_map.addApiarySite(site_updated);
                 } catch (error) {
                     swal.fire({
                         title: 'Error',
@@ -885,7 +893,15 @@
                             break;
                         }
                     }
+                    for (let i = 0; i < vm.apiary_site_geojson_array.length; i++) {
+                        if (vm.apiary_site_geojson_array[i].id == apiary_site_id) {
+                            vm.apiary_site_geojson_array[i] = site_updated;
+                            break;
+                        }
+                    }
                     vm.constructApiarySitesTable(vm.apiary_sites_local);
+                    vm.$refs.component_map.removeApiarySiteById(apiary_site_id);
+                    vm.$refs.component_map.addApiarySite(site_updated);
                 } catch (error) {
                     swal.fire({
                         title: 'Error',

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -805,7 +805,7 @@
                 let vm = this;
                 let apiary_site_id = e.target.getAttribute('data-suspend-site');
                 e.stopPropagation();
-                const result = await Swal.fire({
+                const result = await swal.fire({
                     title: 'Suspend Site ' + apiary_site_id + '?',
                     text: 'Are you sure you want to suspend this site?',
                     icon: 'warning',
@@ -839,7 +839,7 @@
                     }
                     vm.constructApiarySitesTable(vm.apiary_sites_local);
                 } catch (error) {
-                    Swal.fire({
+                    swal.fire({
                         title: 'Error',
                         text: String(error),
                         icon: 'error',
@@ -851,7 +851,7 @@
                 let vm = this;
                 let apiary_site_id = e.target.getAttribute('data-reinstate-site');
                 e.stopPropagation();
-                const result = await Swal.fire({
+                const result = await swal.fire({
                     title: 'Reinstate Site ' + apiary_site_id + '?',
                     text: 'Are you sure you want to reinstate this site?',
                     icon: 'question',
@@ -885,7 +885,7 @@
                     }
                     vm.constructApiarySitesTable(vm.apiary_sites_local);
                 } catch (error) {
-                    Swal.fire({
+                    swal.fire({
                         title: 'Error',
                         text: String(error),
                         icon: 'error',

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -804,6 +804,7 @@
             suspendApiarySite: async function(e) {
                 let vm = this;
                 let apiary_site_id = e.target.getAttribute('data-suspend-site');
+                e.preventDefault();
                 e.stopPropagation();
                 const result = await swal.fire({
                     title: 'Suspend Site ' + apiary_site_id + '?',
@@ -850,6 +851,7 @@
             reinstateApiarySite: async function(e) {
                 let vm = this;
                 let apiary_site_id = e.target.getAttribute('data-reinstate-site');
+                e.preventDefault();
                 e.stopPropagation();
                 const result = await swal.fire({
                     title: 'Reinstate Site ' + apiary_site_id + '?',

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -435,6 +435,20 @@
                                     let ret = '<a data-contact-licence-holder="' + apiary_site.id + '">' + display_text + '</a>';
                                     action_list.push(ret);
                                 }
+                                if (vm.show_action_suspend_reinstate) {
+                                    const status = apiary_site.properties.status
+                                        ? apiary_site.properties.status.toLowerCase()
+                                        : '';
+                                    if (status === 'current') {
+                                        action_list.push(
+                                            '<a href="#" data-suspend-site="' + apiary_site.id + '">Suspend</a>'
+                                        );
+                                    } else if (status === 'suspended') {
+                                        action_list.push(
+                                            '<a href="#" data-reinstate-site="' + apiary_site.id + '">Reinstate</a>'
+                                        );
+                                    }
+                                }
                                 return action_list.join('<br />');
                             },
                             defaultContent: '',

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -43,6 +43,7 @@
         constants
     }from '@/utils/hooks'
     import $ from 'jquery';
+    import helpers from '@/utils/helpers';
 
     export default {
         props:{
@@ -798,6 +799,98 @@
                             confirmButton: 'btn btn-primary',
                         },
                     })
+                }
+            },
+            suspendApiarySite: async function(e) {
+                let vm = this;
+                let apiary_site_id = e.target.getAttribute('data-suspend-site');
+                e.stopPropagation();
+                const result = await Swal.fire({
+                    title: 'Suspend Site ' + apiary_site_id + '?',
+                    text: 'Are you sure you want to suspend this site?',
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonText: 'Suspend',
+                    customClass: { confirmButton: 'btn btn-primary', cancelButton: 'btn btn-secondary' },
+                });
+                if (!result.isConfirmed) return;
+                try {
+                    const response = await fetch(
+                        '/api/approvals/' + vm.apiary_approval_id + '/suspend_apiary_site/',
+                        {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': helpers.getCookie('csrftoken'),
+                            },
+                            body: JSON.stringify({ apiary_site_id: apiary_site_id }),
+                        }
+                    );
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(errorText);
+                    }
+                    const site_updated = await response.json();
+                    for (let i = 0; i < vm.apiary_sites_local.length; i++) {
+                        if (vm.apiary_sites_local[i].id == apiary_site_id) {
+                            vm.apiary_sites_local[i] = site_updated;
+                            break;
+                        }
+                    }
+                    vm.constructApiarySitesTable(vm.apiary_sites_local);
+                } catch (error) {
+                    Swal.fire({
+                        title: 'Error',
+                        text: String(error),
+                        icon: 'error',
+                        customClass: { confirmButton: 'btn btn-primary' },
+                    });
+                }
+            },
+            reinstateApiarySite: async function(e) {
+                let vm = this;
+                let apiary_site_id = e.target.getAttribute('data-reinstate-site');
+                e.stopPropagation();
+                const result = await Swal.fire({
+                    title: 'Reinstate Site ' + apiary_site_id + '?',
+                    text: 'Are you sure you want to reinstate this site?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: 'Reinstate',
+                    customClass: { confirmButton: 'btn btn-primary', cancelButton: 'btn btn-secondary' },
+                });
+                if (!result.isConfirmed) return;
+                try {
+                    const response = await fetch(
+                        '/api/approvals/' + vm.apiary_approval_id + '/reinstate_apiary_site/',
+                        {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': helpers.getCookie('csrftoken'),
+                            },
+                            body: JSON.stringify({ apiary_site_id: apiary_site_id }),
+                        }
+                    );
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(errorText);
+                    }
+                    const site_updated = await response.json();
+                    for (let i = 0; i < vm.apiary_sites_local.length; i++) {
+                        if (vm.apiary_sites_local[i].id == apiary_site_id) {
+                            vm.apiary_sites_local[i] = site_updated;
+                            break;
+                        }
+                    }
+                    vm.constructApiarySitesTable(vm.apiary_sites_local);
+                } catch (error) {
+                    Swal.fire({
+                        title: 'Error',
+                        text: String(error),
+                        icon: 'error',
+                        customClass: { confirmButton: 'btn btn-primary' },
+                    });
                 }
             },
             zoomOnApiarySite: function(e) {

--- a/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
+++ b/disturbance/frontend/disturbance/src/components/common/apiary/component_site_selection.vue
@@ -166,7 +166,11 @@
             can_modify: {
                 type: Boolean,
                 default: false,
-            }
+            },
+            show_action_suspend_reinstate: {
+                type: Boolean,
+                default: false,
+            },
         },
         data: function(){
             let vm = this;

--- a/disturbance/frontend/disturbance/src/components/internal/approvals/apiary_approval.vue
+++ b/disturbance/frontend/disturbance/src/components/internal/approvals/apiary_approval.vue
@@ -154,6 +154,7 @@
                         :show_col_checkbox="false"
                         :show_col_status="true"
                         :apiary_approval_id="approval.id"
+                        :show_action_suspend_reinstate="true"
                     />
                 </template>
             </FormSection>


### PR DESCRIPTION
## Summary

Add the ability for internal staff to suspend or reinstate individual
apiary sites from the approval detail page (/internal/approval/<id>),
without affecting the overall approval status.

## Changes

### Backend
- `approvals/models.py`: Add `suspend_apiary_site()` and `reinstate_apiary_site()` methods
  with safety guards (`approval.status == CURRENT` and `can_action == True`).
  Add corresponding `ApprovalUserAction` constants.
  Fix `change_apiary_site_status()` (Option B): preserve `SUSPENDED` sites
  when approval-level suspend/reinstate cascades.
- `approvals/api.py`: Add `suspend_apiary_site` and `reinstate_apiary_site`
  POST endpoints on `ApprovalViewSet` (InternalApprovalPermission).
- `proposals/models.py`: Fix `_update_apiary_sites()` to only set
  `site_status = CURRENT` for newly created `ApiarySiteOnApproval` records,
  preserving individual suspensions across renewal/amendment.

### Frontend
- `component_site_selection.vue`: Add `show_action_suspend_reinstate` prop.
  Render Suspend/Reinstate links in the Action column based on current
  site status. On confirmation, POST to the API, update the table and map
  in-place (no full map re-mount, preserving zoom/position).
- `apiary_approval.vue`: Pass `:show_action_suspend_reinstate="true"`.

## Design Decisions
- Per-site suspend uses `SITE_STATUS_SUSPENDED`; approval-level cascade
  uses `SITE_STATUS_NOT_TO_BE_REISSUED` — the two are kept distinct.
- Map is updated by `removeApiarySiteById()` + `addApiarySite()` via
  `$refs`, avoiding a full ComponentMap re-mount.